### PR TITLE
Simplify the buffer generation process and GraphicsSprite fields

### DIFF
--- a/client/src/PureSpace/Client/Graphics/Buffer.hs
+++ b/client/src/PureSpace/Client/Graphics/Buffer.hs
@@ -19,47 +19,30 @@
 
 module PureSpace.Client.Graphics.Buffer
   (
-    createVBO,
-    createVAO,
+    spriteVAO
   )
   where
 
-import           Data.Vector.Storable   (fromList, unsafeWith)
-import           Foreign.Storable       (Storable (..), sizeOf)
-import           Graphics.GLUtil        (offset0)
-import           Graphics.UI.GLUT       (AttribLocation (..), BufferObject,
-                                         BufferTarget (..), BufferUsage (..),
-                                         Capability (..), DataType (..),
-                                         GLfloat, IntegerHandling (..),
-                                         NumComponents,
-                                         VertexArrayDescriptor (..),
-                                         VertexArrayObject, bindBuffer,
-                                         bindVertexArrayObject, bufferData,
-                                         genObjectName, vertexAttribArray,
-                                         vertexAttribPointer, ($=))
-import           PureSpace.Common.Monad (MonadIO, liftIO)
+import           Graphics.GLUtil               (offset0, makeBuffer, makeVAO)
+import           Graphics.UI.GLUT              (AttribLocation (..),
+                                                BufferTarget (..),
+                                                Capability (..), DataType (..),
+                                                GLfloat, IntegerHandling (..),
+                                                NumComponents,
+                                                VertexArrayDescriptor (..),
+                                                VertexArrayObject, bindBuffer,
+                                                vertexAttribArray,
+                                                vertexAttribPointer, ($=))
+import           PureSpace.Common.Monad        (MonadIO, liftIO)
 
 vaoComponents :: NumComponents
 vaoComponents = 4
 
-createVBO :: MonadIO m => [GLfloat] -> m (BufferObject, VertexArrayObject)
-createVBO vertices  = do
-  vertexBuffer <- genObjectName
-  bindBuffer ArrayBuffer $= Just vertexBuffer
-  let vector = fromList vertices
-  liftIO $ unsafeWith vector $ \ptr ->
-    bufferData ArrayBuffer $= (bufferSize, ptr, StaticDraw)
-  vertexArray <- createVAO vaoComponents
-  bindBuffer ArrayBuffer                 $= Nothing
-  pure (vertexBuffer, vertexArray)
-  where
-    bufferSize = toEnum $ length vertices * sizeOf (head vertices)
-
-createVAO :: MonadIO m => NumComponents -> m VertexArrayObject
-createVAO numComponents = do
-  vertexArray  <- genObjectName
-  bindVertexArrayObject                  $= Just vertexArray
-  vertexAttribArray   (AttribLocation 0) $= Enabled
-  vertexAttribPointer (AttribLocation 0) $= (ToFloat, VertexArrayDescriptor numComponents Float 0 offset0)
-  bindVertexArrayObject                  $= Nothing
-  pure vertexArray
+spriteVAO :: MonadIO m => [GLfloat] -> m VertexArrayObject
+spriteVAO vertices = liftIO $ makeVAO $
+    do buffer <- makeBuffer ArrayBuffer vertices
+       bindBuffer ArrayBuffer $= Just buffer
+       let attrib0 = AttribLocation 0
+       vertexAttribArray  attrib0 $= Enabled
+       vertexAttribPointer attrib0 $= (ToFloat, VertexArrayDescriptor vaoComponents Float 0 offset0)
+       bindBuffer ArrayBuffer $= Nothing

--- a/client/src/PureSpace/Client/Graphics/Window.hs
+++ b/client/src/PureSpace/Client/Graphics/Window.hs
@@ -38,7 +38,7 @@ Everything under this line is complete garbage atm
 ############################
 -}
 
-data GraphicsSprite = GraphicsSprite Sprite (BufferObject, VertexArrayObject) deriving Show
+data GraphicsSprite = GraphicsSprite Sprite VertexArrayObject deriving Show
 
 openGLVersion :: (Int, Int)
 openGLVersion = (3, 3)
@@ -59,7 +59,7 @@ createGameWindow = do
   (_, _)                   <- getArgsAndInitialize
   window                   <- createWindow "PureSpace"
   (text, sprites, program) <- initContext atlas
-  let (Just ship) = L.find (\(GraphicsSprite (Sprite name _ _ _ _) (_, _)) -> name == "playerShip1_blue.png") sprites
+  let (Just ship) = L.find (\(GraphicsSprite (Sprite name _ _ _ _) _) -> name == "playerShip1_blue.png") sprites
   displayCallback $= display program text ship
   idleCallback    $= Just (postRedisplay (Just window))
   mainLoop
@@ -92,7 +92,7 @@ initSpriteBuffer :: MonadIO m => Int -> Int -> Sprite -> m GraphicsSprite
 initSpriteBuffer imgW imgH sprite@(Sprite _ x y w h) =
   pure GraphicsSprite
   <*> pure sprite
-  <*> createVBO triangles
+  <*> spriteVAO triangles
   where
     norm a b = fromIntegral a / fromIntegral b
     nX = norm x imgW
@@ -113,7 +113,7 @@ initSpriteBuffer imgW imgH sprite@(Sprite _ x y w h) =
       ]
 
 display :: Program -> TextureObject -> GraphicsSprite -> DisplayCallback
-display program text (GraphicsSprite _ (_, vao)) = do
+display program text (GraphicsSprite _ vao) = do
   Size width height <- GLUT.get windowSize
   clear [ColorBuffer, DepthBuffer]
   time <- elapsedTime


### PR DESCRIPTION
Since we already depend on GLUtil and that the library expose convenient utilities to generate VAOs and VBOs, I suggest relying on these to simplify the Client/Graphics/Buffer.hs module.

In the same spirit of simplification, I slightly modified the SpriteGraphics datatype: you typically don't want to carry around the VBO, since you only use the VAO to draw.