### PR TITLE
Put GraphicsSprite in a map

### DIFF
--- a/purespace.cabal
+++ b/purespace.cabal
@@ -82,16 +82,18 @@ executable purespace-client
   ghc-options:         -Wall
   build-depends:       purespace
                      , base >=4.10 && <4.11
-                     , OpenGLRaw
-                     , OpenGL
+                     , aeson
+                     , bytestring
+                     , containers
                      , GLUT
                      , GLUtil
                      , JuicyPixels
-                     , aeson
-                     , vector
-                     , bytestring
                      , linear
+                     , OpenGLRaw
+                     , OpenGL
                      , stm
+                     , vector
+
 test-suite purespace-client-test
   type:                exitcode-stdio-1.0
   main-is:             Spec.hs


### PR DESCRIPTION
A fairly simple and straightfoward PR - let's put the GraphicsSprite in a Map for an easier access than using Find. For the time being, I've put it as a `M.Map String GraphicsSprite`, maybe a custom type for the key would be in order in the future - hence the aliasing on the key type.