### PR TITLE
Add game state datatypes

### DIFF
--- a/common/src/PureSpace/Common/Game/Base/Types.hs
+++ b/common/src/PureSpace/Common/Game/Base/Types.hs
@@ -1,0 +1,90 @@
+-- Types.hs ---
+
+-- Copyright (C) 2018 Hussein Ait-Lahcen
+
+-- Author: Hussein Ait-Lahcen <hussein.aitlahcen@gmail.com>
+
+-- This program is free software; you can redistribute it and/or
+-- modify it under the terms of the GNU General Public License
+-- as published by the Free Software Foundation; either version 3
+-- of the License, or (at your option) any later version.
+
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+module PureSpace.Common.Game.Base.Types
+  (
+    Base (..)
+  , BaseType (..)
+  , HasIncome (..)
+  , HasIsHeadquarter (..)
+  , HasBase (..)
+  , HasBaseType (..)
+  , Income
+  , IsHeadquarter
+  )
+where
+
+
+import           PureSpace.Common.Game.Ship.Types
+import           PureSpace.Common.Game.Types      (HasHealth, HasMaxHealth)
+import           PureSpace.Common.Lens            (Lens', lens)
+
+-- | An amount of cash received regularly
+type Income = Integer
+-- | Headquarters are vital targets; if no headerquarter remains,
+-- a player has lost.
+type IsHeadquarter = Bool
+
+data BaseType = BaseType Income MaxHealth IsHeadquarter deriving Show
+
+-- | Base of a player, providers of income and potentially
+-- main target of an opponent
+data Base = Base BaseType Health Position deriving Show
+
+class HasBase b where
+  base :: Lens' b Base
+
+class HasBaseType b where
+  baseType :: Lens' b BaseType
+
+class HasIncome i where
+  income :: Lens' i Income
+
+class HasIsHeadquarter i where
+  isHeadquarter :: Lens' i IsHeadquarter
+
+instance HasBase Base where
+  base = id
+
+instance HasBaseType BaseType where
+  baseType = id
+
+instance HasBaseType Base where
+ baseType =
+    let f (Base a _ _) = a
+        g (Base _ b c) a = Base a b c
+    in lens f g
+
+instance HasHealth Base where
+  health =
+    let f (Base _ b _) = b
+        g (Base a _ c) b = Base a b c
+    in lens f g
+
+instance HasMaxHealth BaseType where
+  maxHealth =
+    let f (BaseType _ b _) = b
+        g (BaseType a _ c) b = BaseType a b c
+    in lens f g
+
+instance HasIsHeadquarter BaseType where
+  isHeadquarter =
+    let f (BaseType _ _ c) = c
+        g (BaseType a b _) = BaseType a b
+    in lens f g

--- a/common/src/PureSpace/Common/Game/State/GameState.hs
+++ b/common/src/PureSpace/Common/Game/State/GameState.hs
@@ -1,0 +1,56 @@
+-- GameState.hs ---
+
+-- Copyright (C) 2018 Hussein Ait-Lahcen
+
+-- Author: Hussein Ait-Lahcen <hussein.aitlahcen@gmail.com>
+
+-- This program is free software; you can redistribute it and/or
+-- modify it under the terms of the GNU General Public License
+-- as published by the Free Software Foundation; either version 3
+-- of the License, or (at your option) any later version.
+
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+module PureSpace.Common.Game.State.GameState
+  (
+    HasPlayerOne(..)
+  , HasPlayerTwo(..)
+  , GameState(..)
+  )
+where
+
+import           PureSpace.Common.Game.State.Player (Player)
+import           PureSpace.Common.Lens              (Lens', lens)
+
+-- | The state of the game, namely the current situation
+-- of both players. Victory or loss condition can be inferred
+-- from the situation of players at any given time.
+data GameState = GameState Player Player
+
+-- To ponder: maybe an `Ixed` would be better here ?
+-- This might need to be changed. We will see what's more
+-- convenient when writing the main loop.
+
+class HasPlayerOne p where
+  playerOne :: Lens' p Player
+
+class HasPlayerTwo p where
+  playerTwo :: Lens' p Player
+
+instance HasPlayerOne GameState where
+  playerOne =
+    let f (GameState a _) = a
+        g (GameState _ b) a = GameState a b
+    in lens f g
+
+instance HasPlayerTwo GameState where
+  playerTwo =
+    let f (GameState _ b) = b
+        g (GameState a _) = GameState a
+    in lens f g

--- a/common/src/PureSpace/Common/Game/State/Player.hs
+++ b/common/src/PureSpace/Common/Game/State/Player.hs
@@ -1,0 +1,72 @@
+-- Player.hs ---
+
+-- Copyright (C) 2018 Hussein Ait-Lahcen
+
+-- Author: Hussein Ait-Lahcen <hussein.aitlahcen@gmail.com>
+
+-- This program is free software; you can redistribute it and/or
+-- modify it under the terms of the GNU General Public License
+-- as published by the Free Software Foundation; either version 3
+-- of the License, or (at your option) any later version.
+
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+module PureSpace.Common.Game.State.Player
+  (
+    Cash
+  , HasBases (..)
+  , HasCash (..)
+  , HasPlayer (..)
+  , HasShips (..)
+  , Player (..)
+  )
+where
+
+import           PureSpace.Common.Game.Ship.Types
+import           PureSpace.Common.Game.Base.Types
+import           PureSpace.Common.Lens            (Lens', lens)
+
+-- | Currency to be spent on upgrades and units
+type Cash = Integer
+
+data Player = Player [Base] [Ship] Cash deriving Show
+
+class HasPlayer p where
+  player :: Lens' p Player
+
+instance HasPlayer Player where
+  player = id
+
+class HasBases b where
+  bases :: Lens' b [Base]
+
+class HasShips s where
+  ships :: Lens' s [Ship]
+
+class HasCash c where
+  cash :: Lens' c Cash
+
+instance HasBases Player where
+  bases =
+    let f (Player a _ _) = a
+        g (Player _ b c) a = Player a b c
+    in lens f g
+
+instance HasShips Player where
+  ships =
+    let f (Player _ b _) = b
+        g (Player a _ c) b = Player a b c
+    in lens f g
+
+instance HasCash Player where
+  cash =
+    let f (Player _ _ c) = c
+        g (Player a b _) = Player a b
+    in lens f g
+  

--- a/common/src/PureSpace/Common/Game/State/Types.hs
+++ b/common/src/PureSpace/Common/Game/State/Types.hs
@@ -1,0 +1,28 @@
+-- Types.hs ---
+
+-- Copyright (C) 2018 Hussein Ait-Lahcen
+
+-- Author: Hussein Ait-Lahcen <hussein.aitlahcen@gmail.com>
+
+-- This program is free software; you can redistribute it and/or
+-- modify it under the terms of the GNU General Public License
+-- as published by the Free Software Foundation; either version 3
+-- of the License, or (at your option) any later version.
+
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+module PureSpace.Common.Game.State.Types
+  (
+    module PureSpace.Common.Game.State.GameState
+  , module PureSpace.Common.Game.State.Player
+  )
+where
+
+import PureSpace.Common.Game.State.GameState
+import PureSpace.Common.Game.State.Player


### PR DESCRIPTION
A modest contribution to the game model, this PR adds building blocks from which we can start to write a fully-fledged game logic loop.

Note that the Player type is really a stub; the whole economy logic will need to be added later on.