### PR TITLE
Set default window size to 800 * 600

### DIFF
--- a/client/src/PureSpace/Client/Graphics/Window.hs
+++ b/client/src/PureSpace/Client/Graphics/Window.hs
@@ -81,6 +81,7 @@ createGameWindow = do
   gameConf           <- view gameConfig
   gameRef            <- liftIO $ newIORef (game gameConf)
   displayCallback $= debugDisplay gameConf gameRef program sprites
+  windowSize $= Size 800 600
   loadInputState
   windowLoop
   where


### PR DESCRIPTION
On a non-tiling window manager, the default window is rather small. As a result, laser shot are not even displayed, and the scene is hard on myopic eyes like mine. Surely one day we'll add resolution setting, but for now, setting a default will do.